### PR TITLE
Iteration with navigation bar on window pop up removed

### DIFF
--- a/Catalog/SelectedDressViewController.swift
+++ b/Catalog/SelectedDressViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class SelectedDressViewController: UIViewController {
+class SelectedDressViewController: UIViewController, UIGestureRecognizerDelegate {
     
     @IBOutlet weak var ImageView: UIImageView!
     @IBOutlet weak var closeView: UIButton!
@@ -11,6 +11,11 @@ class SelectedDressViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        let gestureRecognizer = UITapGestureRecognizer(target: self,action: #selector(removeAnimate))
+        gestureRecognizer.cancelsTouchesInView = false
+        gestureRecognizer.delegate = self
+        view.addGestureRecognizer(gestureRecognizer)
+        
         self.view.removeFromSuperview()
         self.showAnimate()
         ImageView.image = UIImage(named: dressImage)
@@ -18,6 +23,10 @@ class SelectedDressViewController: UIViewController {
     
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
+    }
+    
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        return (touch.view === self.view)
     }
     
     @IBAction func closeWindow(sender: UIButton) {

--- a/Catalog/SelectionViewController.swift
+++ b/Catalog/SelectionViewController.swift
@@ -77,6 +77,7 @@ class SelectionViewController: UIViewController, UITableViewDataSource, UITableV
         self.addChildViewController(popImageView)
         popImageView.view.frame = self.view.frame
         self.view.addSubview(popImageView.view)
+        self.navigationController?.view.addSubview(popImageView.view)
         popImageView.didMove(toParentViewController: self)
         tableView.deselectRow(at: indexPath, animated: true)
     }
@@ -94,6 +95,7 @@ class SelectionViewController: UIViewController, UITableViewDataSource, UITableV
         self.addChildViewController(popCompleteView)
         popCompleteView.view.frame = self.view.frame
         self.view.addSubview(popCompleteView.view)
+        self.navigationController?.view.addSubview(popCompleteView.view)
         popCompleteView.didMove(toParentViewController: self)
     }
     


### PR DESCRIPTION
When confirmation window or dress images pop up, the navigation bar also goes to the background, keeping the user from interact with it. Additionally, when the user clicks outised selected dress popup, the window also closes.